### PR TITLE
Python rewrite

### DIFF
--- a/python/construction.py
+++ b/python/construction.py
@@ -433,6 +433,8 @@ class ConstructionWriter:
                 _tag["blocks_array_type"] = amulet_nbt.TAG_Byte(-1)
             else:
                 flattened_array = blocks.ravel()
+                index, flattened_array = numpy.unique(flattened_array, return_inverse=True)
+                palette = numpy.array(palette, dtype=object)[index]
                 lut = numpy.vectorize(self._palette.get_add_block)(palette)
                 flattened_array = lut[flattened_array]
                 array_type = self._find_fitting_array_type(flattened_array)

--- a/python/construction.py
+++ b/python/construction.py
@@ -97,6 +97,14 @@ class ConstructionReader:
         self._init_read()
 
     @property
+    def metadata(self) -> amulet_nbt.NBTFile:
+        return self._metadata
+
+    @property
+    def palette(self) -> List[Block]:
+        return self._palette.copy()
+
+    @property
     def sections(self) -> List[Tuple[int, int, int, int, int, int, int, int]]:
         return self._section_index_table.copy()
 
@@ -110,7 +118,7 @@ class ConstructionReader:
 
     @property
     def selection(self) -> List[Tuple[int, int, int, int, int, int]]:
-        return self._selection_boxes
+        return self._selection_boxes.copy()
 
     def __enter__(self):
         return self

--- a/python/construction.py
+++ b/python/construction.py
@@ -237,7 +237,7 @@ class ConstructionWriter:
             self._metadata = amulet_nbt.NBTFile(
                 amulet_nbt.TAG_Compound(
                     {
-                        "created_with": "amulet_python_wrapper",
+                        "created_with": amulet_nbt.TAG_String("amulet_python_wrapper"),
                         "selection_boxes": amulet_nbt.TAG_Int_Array([c for box in self._selection_boxes if len(box) == 6 and all(isinstance(c, int) for c in box) for c in box]),
                         "section_version": amulet_nbt.TAG_Byte(self._section_version),
                         "export_version": amulet_nbt.TAG_Compound(

--- a/python/construction.py
+++ b/python/construction.py
@@ -111,13 +111,13 @@ class ConstructionReader:
         block_palette = []
         extra_block_map = {}
         for block_index, block_nbt in enumerate(raw_palette):
+            block_nbt: amulet_nbt.TAG_Compound
             block_namespace = block_nbt["namespace"].value
             block_basename = block_nbt["blockname"].value
-            properties = {key: v for key, v in block_nbt["properties"].items()}
             block = Block(
                 namespace=block_namespace,
                 base_name=block_basename,
-                properties=properties,
+                properties=block_nbt["properties"].value,
             )
 
             if block_nbt["extra_blocks"].value:
@@ -299,12 +299,7 @@ class ConstructionWriter:
             {
                 "namespace": amulet_nbt.TAG_String(_block.namespace),
                 "blockname": amulet_nbt.TAG_String(_block.base_name),
-                "properties": amulet_nbt.TAG_Compound(
-                    {
-                        prop: amulet_nbt.TAG_String(value.value)
-                        for prop, value in _block.properties.items()
-                    }
-                ),
+                "properties": amulet_nbt.TAG_Compound(_block.properties),
                 "extra_blocks": amulet_nbt.TAG_List(
                     [
                         amulet_nbt.TAG_Int(

--- a/python/construction.py
+++ b/python/construction.py
@@ -200,12 +200,12 @@ class ConstructionReader:
     def _parse_entities(entities: amulet_nbt.TAG_List) -> List[Entity]:
         return [
             Entity(
-                entity["namespace"],
-                entity["base_name"],
-                entity["x"],
-                entity["y"],
-                entity["z"],
-                entity["nbt"],
+                entity["namespace"].value,
+                entity["base_name"].value,
+                entity["x"].value,
+                entity["y"].value,
+                entity["z"].value,
+                amulet_nbt.NBTFile(entity["nbt"]),
             ) for entity in entities
         ]
 
@@ -213,12 +213,12 @@ class ConstructionReader:
     def _parse_block_entities(block_entities: amulet_nbt.TAG_List) -> List[BlockEntity]:
         return [
             BlockEntity(
-                block_entity["namespace"],
-                block_entity["base_name"],
-                block_entity["x"],
-                block_entity["y"],
-                block_entity["z"],
-                block_entity["nbt"],
+                block_entity["namespace"].value,
+                block_entity["base_name"].value,
+                block_entity["x"].value,
+                block_entity["y"].value,
+                block_entity["z"].value,
+                amulet_nbt.NBTFile(block_entity["nbt"]),
             ) for block_entity in block_entities
         ]
 
@@ -340,7 +340,7 @@ class ConstructionWriter:
                 "x": amulet_nbt.TAG_Double(entity.x),
                 "y": amulet_nbt.TAG_Double(entity.y),
                 "z": amulet_nbt.TAG_Double(entity.z),
-                "nbt": amulet_nbt.TAG_Compound(entity.nbt.value)
+                "nbt": entity.nbt.value
             }) for entity in entities
         ])
 
@@ -353,7 +353,7 @@ class ConstructionWriter:
                 "x": amulet_nbt.TAG_Int(block_entity.x),
                 "y": amulet_nbt.TAG_Int(block_entity.y),
                 "z": amulet_nbt.TAG_Int(block_entity.z),
-                "nbt": amulet_nbt.TAG_Compound(block_entity.nbt.value)
+                "nbt": block_entity.nbt.value
             }) for block_entity in block_entities
         ])
 

--- a/python/construction.py
+++ b/python/construction.py
@@ -345,6 +345,9 @@ class ConstructionWriter:
     def write(self, *args, **_):
         if self._section_version == 0:
             (sx, sy, sz), (shapex, shapey, shapez), blocks, palette, entities, block_entities = args
+            for point, shape in zip((sx, sy, sz), (shapex, shapey, shapez)):
+                assert shape >= 0, 'Shape must be positive'
+                assert point + shape <= (((point >> 4)+1) << 4), 'Section does not fit in a sub-chunk'
             position = self._buffer.tell()
 
             _tag = amulet_nbt.TAG_Compound(

--- a/python/construction.py
+++ b/python/construction.py
@@ -5,6 +5,8 @@ import struct
 from typing import Type, Union, Tuple, IO, List, Optional
 
 from amulet import Block, BlockManager
+from amulet.api.entity import Entity
+from amulet.api.block_entity import BlockEntity
 
 import amulet_nbt
 
@@ -40,8 +42,8 @@ class ConstructionSection:
         shape: INT_TRIPLET,
         blocks: Optional[numpy.ndarray],
         palette: List[Block],
-        entities: List[amulet_nbt.TAG_Compound],
-        block_entities: Optional[List[amulet_nbt.TAG_Compound]],
+        entities: List[Entity],
+        block_entities: List[BlockEntity],
     ):
         self.sx, self.sy, self.sz = min_position
         self.shape = shape
@@ -174,6 +176,32 @@ class ConstructionReader:
         else:
             raise Exception(f"This wrapper doesn\'t support any construction version higher than {max_format_version}")
 
+    @staticmethod
+    def _parse_entities(entities: amulet_nbt.TAG_List) -> List[Entity]:
+        return [
+            Entity(
+                entity["namespace"],
+                entity["base_name"],
+                entity["x"],
+                entity["y"],
+                entity["z"],
+                entity["nbt"],
+            ) for entity in entities
+        ]
+
+    @staticmethod
+    def _parse_block_entities(block_entities: amulet_nbt.TAG_List) -> List[BlockEntity]:
+        return [
+            BlockEntity(
+                block_entity["namespace"],
+                block_entity["base_name"],
+                block_entity["x"],
+                block_entity["y"],
+                block_entity["z"],
+                block_entity["nbt"],
+            ) for block_entity in block_entities
+        ]
+
     def read(self, section_index: int):
         if self._format_version == 0:
             sx, sy, sz, shapex, shapey, shapez, position, length = self._section_index_table[section_index]
@@ -184,14 +212,14 @@ class ConstructionReader:
                 block_entities = None
             else:
                 blocks = numpy.reshape(nbt_obj["blocks"].value, (shapex, shapey, shapez))
-                block_entities = nbt_obj["block_entities"].value
+                block_entities = self._parse_block_entities(nbt_obj["block_entities"])
 
             return ConstructionSection(
                 (sx, sy, sz),
                 (shapex, shapey, shapez),
                 blocks,
                 self._palette,
-                nbt_obj["entities"].value,
+                self._parse_entities(nbt_obj["entities"]),
                 block_entities,
             )
         else:
@@ -288,6 +316,32 @@ class ConstructionWriter:
             }
         )
 
+    @staticmethod
+    def _serialise_entities(entities: List[Entity]) -> amulet_nbt.TAG_List:
+        return amulet_nbt.TAG_List([
+            amulet_nbt.TAG_Compound({
+                "namespace": amulet_nbt.TAG_String(entity.namespace),
+                "base_name": amulet_nbt.TAG_String(entity.base_name),
+                "x": amulet_nbt.TAG_Double(entity.x),
+                "y": amulet_nbt.TAG_Double(entity.y),
+                "z": amulet_nbt.TAG_Double(entity.z),
+                "nbt": amulet_nbt.TAG_Compound(entity.nbt.value)
+            }) for entity in entities
+        ])
+
+    @staticmethod
+    def _serialise_block_entities(block_entities: List[BlockEntity]) -> amulet_nbt.TAG_List:
+        return amulet_nbt.TAG_List([
+            amulet_nbt.TAG_Compound({
+                "namespace": amulet_nbt.TAG_String(block_entity.namespace),
+                "base_name": amulet_nbt.TAG_String(block_entity.base_name),
+                "x": amulet_nbt.TAG_Int(block_entity.x),
+                "y": amulet_nbt.TAG_Int(block_entity.y),
+                "z": amulet_nbt.TAG_Int(block_entity.z),
+                "nbt": amulet_nbt.TAG_Compound(block_entity.nbt.value)
+            }) for block_entity in block_entities
+        ])
+
     def _pack_palette(self) -> amulet_nbt.TAG_List:
         block_palette_nbt = amulet_nbt.TAG_List()
         extra_blocks = set()
@@ -356,7 +410,7 @@ class ConstructionWriter:
 
             _tag = amulet_nbt.TAG_Compound(
                 {
-                    "entities": amulet_nbt.TAG_List(entities)
+                    "entities": self._serialise_entities(entities)
                 }
             )
 
@@ -369,7 +423,7 @@ class ConstructionWriter:
                 array_type = self._find_fitting_array_type(flattened_array)
                 _tag["blocks_array_type"] = amulet_nbt.TAG_Byte(array_type().tag_id)
                 _tag["blocks"] = array_type(flattened_array)
-                _tag["block_entities"] = amulet_nbt.TAG_List(block_entities or [])
+                _tag["block_entities"] = self._serialise_block_entities(block_entities or [])
 
             amulet_nbt.NBTFile(_tag).save_to(self._buffer)
 

--- a/python/construction.py
+++ b/python/construction.py
@@ -100,6 +100,14 @@ class ConstructionReader:
     def sections(self) -> List[Tuple[int, int, int, int, int, int, int, int]]:
         return self._section_index_table.copy()
 
+    @property
+    def source_edition(self) -> str:
+        return self._source_edition
+
+    @property
+    def source_version(self) -> INT_TRIPLET:
+        return self._source_version
+
     def __enter__(self):
         return self
 

--- a/python/construction.py
+++ b/python/construction.py
@@ -108,6 +108,10 @@ class ConstructionReader:
     def source_version(self) -> INT_TRIPLET:
         return self._source_version
 
+    @property
+    def selection(self) -> List[Tuple[int, int, int, int, int, int]]:
+        return self._selection_boxes
+
     def __enter__(self):
         return self
 

--- a/python/construction.py
+++ b/python/construction.py
@@ -1,303 +1,107 @@
 from __future__ import annotations
 
-import io
 import os
 import struct
-from typing import Type, Union, Tuple, IO, Dict, List, Optional
+from typing import Type, Union, Tuple, IO, List, Optional, overload
 
-from amulet import Block
+from amulet import Block, BlockManager
+from amulet.api.entity import Entity
+from amulet.api.block_entity import BlockEntity
 
-import amulet_nbt as nbt
+import amulet_nbt
 
-import numpy as np
+import numpy
 
 INT_TRIPLET = Tuple[int, int, int]
 
 INT_STRUCT = struct.Struct(">I")
-SECTION_ENTRY_STRUCT = struct.Struct(">IIIBBBII")
+SECTION_ENTRY_TYPE = numpy.dtype([
+    ('sx', 'i4'),
+    ('sy', 'i4'),
+    ('sz', 'i4'),
+    ('shapex', 'i1'),
+    ('shapey', 'i1'),
+    ('shapez', 'i1'),
+    ('position', 'i4'),
+    ('length', 'i4')
+])
 
+magic_num = b"constrct"
+magic_num_len = len(magic_num)
 
-def find_fitting_array_type(
-    array: np.ndarray
-) -> Type[Union[nbt.TAG_Int_Array, nbt.TAG_Byte_Array, nbt.TAG_Long_Array]]:
-    max_element = array.max(initial=0)
-
-    if max_element <= 127:
-        return nbt.TAG_Byte_Array
-    elif max_element <= 2_147_483_647:
-        return nbt.TAG_Int_Array
-    else:
-        return nbt.TAG_Long_Array
+max_format_version = 0
+max_section_version = 0
 
 
 class ConstructionSection:
-    __slots__ = ("sx", "sy", "sz", "blocks", "entities", "tile_entities")
+    __slots__ = ("sx", "sy", "sz", "blocks", "shape", "entities", "block_entities")
 
     def __init__(
         self,
-        sx: int,
-        sy: int,
-        sz: int,
-        blocks: np.ndarray,
-        entities: list,
-        tile_entities: list,
+        min_position: INT_TRIPLET,
+        shape: INT_TRIPLET,
+        blocks: Optional[numpy.ndarray],
+        entities: List[Entity],
+        block_entities: Optional[List[BlockEntity]],
     ):
-        self.sx = sx
-        self.sy = sy
-        self.sz = sz
+        self.sx, self.sy, self.sz = min_position
+        self.shape = shape
         self.blocks = blocks
         self.entities = entities
-        self.tile_entities = tile_entities
+        self.block_entities = block_entities
 
     def __eq__(self, other):
-        if not isinstance(other, ConstructionSection):
-            return False
         return (
-            self.sx == other.sx
+            isinstance(other, ConstructionSection)
+            and self.sx == other.sx
             and self.sy == other.sy
             and self.sz == other.sz
-            and np.equal(self.blocks, other.blocks).all()
+            and self.shape == other.shape
+            and numpy.equal(self.blocks, other.blocks).all()
             and self.entities == other.entities
-            and self.tile_entities == other.tile_entities
+            and self.block_entities == other.block_entities
         )
 
 
-class Construction:
+class ConstructionReader:
     def __init__(
         self,
-        sections: Dict[INT_TRIPLET, ConstructionSection],
-        palette,
-        source_edition: str,
-        source_version: INT_TRIPLET,
-        selection_boxes: Optional[List[Tuple[int, int, int, int, int, int]]] = None,
+        file_or_buffer: Union[str, IO]
     ):
-        self.sections = sections
-        self.palette = palette
-        self.source_edition = source_edition
-        self.source_version = source_version
-        self.selection_boxes = selection_boxes
+        self._format_version: Optional[int] = None
+        self._section_version: Optional[int] = None
 
-    def __eq__(self, other):
-        if not isinstance(other, Construction):
-            return False
-        return (
-            self.sections == other.sections
-            and self.source_edition == other.source_edition
-            and self.source_version == other.source_version
-        )
-
-    @classmethod
-    def create_from(
-        cls, iterable, palette, edition_name, edition_version, selection_boxes
-    ) -> Construction:
-        sections = {}
-        for section in iterable:
-            section_coords = (section.sx, section.sy, section.sz)
-            sections[section_coords] = ConstructionSection(
-                *section_coords, section.blocks, section.entities, section.tile_entities
-            )
-
-        return cls(sections, palette, edition_name, edition_version, selection_boxes)
-
-    def save(self, filename: str = None, buffer: IO = None):
-        if filename is None and buffer is None:
-            raise Exception()
-
-        if filename is not None:
-            buffer = open(filename, "wb+")
-
-        def generate_section_entry(_section: ConstructionSection) -> nbt.NBTFile:
-            flattened_array = _section.blocks.ravel()
-            array_type = find_fitting_array_type(flattened_array)
-            _tag = nbt.TAG_Compound(
-                {
-                    "entities": nbt.TAG_List(_section.entities),
-                    "tile_entities": nbt.TAG_List(_section.tile_entities),
-                    "blocks": array_type(flattened_array),
-                    "blocks_array_type": nbt.TAG_Byte(array_type().tag_id),
-                }
-            )
-            return nbt.NBTFile(_tag)
-
-        def generate_block_entry(
-            _block: Block, _palette_len, _extra_blocks
-        ) -> nbt.TAG_Compound:
-            return nbt.TAG_Compound(
-                {
-                    "namespace": nbt.TAG_String(_block.namespace),
-                    "blockname": nbt.TAG_String(_block.base_name),
-                    "properties": nbt.TAG_Compound(
-                        {
-                            prop: nbt.TAG_String(value.value)
-                            for prop, value in _block.properties.items()
-                        }
-                    ),
-                    "extra_blocks": nbt.TAG_List(
-                        [
-                            nbt.TAG_Int(
-                                _palette_len + _extra_blocks.index(_extra_block)
-                            )
-                            for _extra_block in _block.extra_blocks
-                        ]
-                    ),
-                }
-            )
-
-        magic_num = "constrct".encode("utf-8")
-        buffer.write(struct.pack(f">{len(magic_num)}s", magic_num))
-        buffer.write(struct.pack(">B", 0))
-
-        section_map = {}
-        for section_coords, section_data in self.sections.items():
-            buffer_position = buffer.tell()
-            section_buffer = io.BytesIO()
-            generate_section_entry(section_data).save_to(
-                filename_or_buffer=section_buffer, compressed=True
-            )
-            buffer.write(section_buffer.getvalue())
-            section_map[section_coords] = (
-                buffer_position,
-                buffer.tell() - buffer_position,
-            )
-
-        sx_max = max(map(lambda s: s[0], section_map.keys()))
-        sy_max = max(map(lambda s: s[1], section_map.keys()))
-        sz_max = max(map(lambda s: s[2], section_map.keys()))
-
-        sx_min = min(map(lambda s: s[0], section_map.keys()))
-        sy_min = min(map(lambda s: s[1], section_map.keys()))
-        sz_min = min(map(lambda s: s[2], section_map.keys()))
-
-        min_structure_coords = (sx_min, sy_min, sz_min)
-        structure_size = (
-            (sx_max - sx_min) + 1,
-            (sy_max - sy_min) + 1,
-            (sz_max - sz_min) + 1,
-        )
-
-        metadata = nbt.TAG_Compound(
-            {
-                "section_version": nbt.TAG_Byte(0),
-                "export_version": nbt.TAG_Compound(
-                    {
-                        "edition": nbt.TAG_String(self.source_edition),
-                        "version": nbt.TAG_List(
-                            [nbt.TAG_Int(v) for v in self.source_version]
-                        ),
-                    }
-                ),
-            }
-        )
-
-        if self.selection_boxes:
-            selection_boxes = [0] * len(self.selection_boxes) * 6
-            for i, box in enumerate(self.selection_boxes):
-                for index, box_coordinate in enumerate(box):
-                    selection_boxes[(i * 6) + index] = box_coordinate
+        if isinstance(file_or_buffer, str):
+            assert os.path.isfile(file_or_buffer), f'There is no file located at {file_or_buffer}'
+            self._buffer = open(file_or_buffer, "rb")
         else:
-            selection_boxes = [
-                0,
-                0,
-                0,
-                structure_size[0],
-                structure_size[1],
-                structure_size[2],
-            ]
+            assert hasattr(file_or_buffer, "read"), "Construction file buffer does not have a read mode"
+            self._buffer = file_or_buffer
 
-        metadata["selection_boxes"] = nbt.TAG_Int_Array(selection_boxes)
+        self._source_edition: Optional[str] = None
+        self._source_version: Optional[INT_TRIPLET] = None
 
-        section_table = [0] * (len(self.sections) * SECTION_ENTRY_STRUCT.size)
-        for i, coordinates in enumerate(self.sections):
-            section = self.sections[coordinates]
+        self._selection_boxes: Optional[List[Tuple[int, int, int, int, int, int]]] = None
 
-            encoded_bytes = SECTION_ENTRY_STRUCT.pack(
-                *coordinates, *section.blocks.shape, *section_map[coordinates]
-            )
-            start_index = i * SECTION_ENTRY_STRUCT.size
-            for byte_pos, byte_value in enumerate(encoded_bytes):
-                section_table[start_index + byte_pos] = byte_value
+        self._metadata: Optional[amulet_nbt.NBTFile] = None
+        self._section_index_table: Optional[List[Tuple[int, int, int, int, int, int, int, int]]] = None
+        self._palette: Optional[amulet_nbt.TAG_List] = None
+        self._init_read()
 
-        metadata["section_index_table"] = nbt.TAG_Byte_Array(section_table)
+    @property
+    def sections(self) -> List[Tuple[int, int, int, int, int, int, int, int]]:
+        return self._section_index_table.copy()
 
-        block_palette_nbt = nbt.TAG_List()
-        extra_blocks = set()
+    def __enter__(self):
+        return self
 
-        for block in self.palette:
-            if len(block.extra_blocks) > 0:
-                extra_blocks.update(block.extra_blocks)
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
 
-        extra_blocks = list(extra_blocks)
-
-        palette_len = len(self.palette)
-        for block_entry in self.palette:
-            block_palette_nbt.append(
-                generate_block_entry(block_entry, palette_len, extra_blocks)
-            )
-
-        for extra_block in extra_blocks:
-            block_palette_nbt.append(
-                generate_block_entry(extra_block, palette_len, extra_blocks)
-            )
-
-        metadata["block_palette"] = block_palette_nbt
-
-        position = buffer.tell()
-        metadata_buffer = io.BytesIO()
-        nbt.NBTFile(metadata).save_to(
-            filename_or_buffer=metadata_buffer, compressed=True
-        )
-        buffer.write(metadata_buffer.getvalue())
-        buffer.write(INT_STRUCT.pack(position))
-        buffer.write(struct.pack(f">{len(magic_num)}s", magic_num))
-
-        buffer.close()
-
-    @classmethod
-    def load(cls, filename: str = None, buffer: IO = None) -> Construction:
-
-        if filename is not None:
-            buffer = open(filename, "rb")
-
-        magic_num_1 = buffer.read(8).decode("utf-8")
-        version_num = struct.unpack(">B", buffer.read(1))[0]
-        buffer.seek(-8, os.SEEK_END)
-        magic_num_2 = buffer.read(8).decode("utf-8")
-
-        if magic_num_1 != "constrct" or magic_num_2 != "constrct":
-            raise AssertionError(
-                f'Invalid magic number: expected: "constrct", got {magic_num_1} at the beginning and {magic_num_2} at the end of the buffer'
-            )
-
-        if version_num != 0:
-            raise AssertionError(
-                "This wrapper doesn't support any construction version higher than 0"
-            )
-
-        buffer.seek(-8, os.SEEK_END)
-        buffer_size = buffer.tell()
-        buffer.seek(buffer_size - INT_STRUCT.size)
-        metadata_position = INT_STRUCT.unpack(buffer.read(INT_STRUCT.size))[0]
-
-        buffer.seek(metadata_position)
-
-        metadata = nbt.load(
-            buffer=buffer.read(buffer_size - (metadata_position + INT_STRUCT.size)),
-            compressed=True,
-        )
-
-        try:
-            edition_name = metadata["export_version"]["edition"].value
-            edition_version = tuple(
-                map(lambda v: v.value, metadata["export_version"]["version"])
-            )
-        except KeyError as e:
-            raise AssertionError(
-                f'Missing export version identifying key "{e.args[0]}"'
-            )
-
+    def _unpack_palette(self, raw_palette: amulet_nbt.TAG_List) -> List[Block]:
         block_palette = []
         extra_block_map = {}
-        for block_index, block_nbt in enumerate(metadata["block_palette"]):
+        for block_index, block_nbt in enumerate(raw_palette):
             block_namespace = block_nbt["namespace"].value
             block_basename = block_nbt["blockname"].value
             properties = {key: v for key, v in block_nbt["properties"].items()}
@@ -320,38 +124,245 @@ class Construction:
                 resulting_block = resulting_block + extra_block
 
             block_palette[block_index] = resulting_block
+        return block_palette
 
-        selection_boxes = []
-        for box_index in range(0, len(metadata["selection_boxes"]), 6):
-            selection_boxes.append(
-                tuple(map(lambda i: metadata["selection_boxes"].value[(box_index * 6) + i], range(6)))
+    def _init_read(self):
+        """data to be read at init in read mode"""
+        magic_num_1 = self._buffer.read(8)
+        assert magic_num_1 == magic_num, f'This file is not a construction file.'
+        self._format_version = struct.unpack_from(">B", self._buffer)[0]
+        if self._format_version == 0:
+            self._buffer.seek(-magic_num_len, os.SEEK_END)
+            magic_num_2 = self._buffer.read(8)
+            assert magic_num_2 == magic_num, 'It looks like this file is corrupt. It probably wasn\'t saved properly'
+
+            self._buffer.seek(-magic_num_len - INT_STRUCT.size)
+            metadata_end = self._buffer.tell()
+            metadata_start = INT_STRUCT.unpack_from(self._buffer)[0]
+            self._buffer.seek(metadata_start)
+
+            metadata = amulet_nbt.load(
+                buffer=self._buffer.read(metadata_end - metadata_start),
+                compressed=True,
             )
 
-        section_index_table = (
-            metadata["section_index_table"].value.astype(np.uint8).tolist()
-        )
-
-        def section_iter():
-            for i in range(len(section_index_table) // SECTION_ENTRY_STRUCT.size):
-                entry_index = i * SECTION_ENTRY_STRUCT.size
-                sx, sy, sz, shapex, shapey, shapez, position, length = SECTION_ENTRY_STRUCT.unpack(
-                    bytes(section_index_table[entry_index : entry_index + 23])
+            try:
+                self._source_edition = metadata["export_version"]["edition"].value
+                self._source_version = tuple(
+                    map(lambda v: v.value, metadata["export_version"]["version"])
+                )
+            except KeyError as e:
+                raise AssertionError(
+                    f'Missing export version identifying key "{e.args[0]}"'
                 )
 
-                buffer.seek(position)
+            self._section_version = metadata["section_version"].value
 
-                nbt_obj = nbt.load(buffer=buffer.read(length), compressed=True)
+            self._palette = self._unpack_palette(metadata["block_palette"])
 
-                yield ConstructionSection(
-                    sx,
-                    sy,
-                    sz,
-                    np.reshape(nbt_obj["blocks"].value, (shapex, shapey, shapez)),
-                    nbt_obj["entities"].value,
-                    nbt_obj["tile_entities"].value,
+            self._selection_boxes = metadata["selection_boxes"].value.reshape(-1, 6).tolist()
+
+            self._section_index_table = metadata["section_index_table"].value.view(SECTION_ENTRY_TYPE).tolist()
+
+        else:
+            raise Exception(f"This wrapper doesn\'t support any construction version higher than {max_format_version}")
+
+    def read(self, section_index: int):
+        if self._format_version == 0:
+            sx, sy, sz, shapex, shapey, shapez, position, length = self._section_index_table[section_index]
+            self._buffer.seek(position)
+            nbt_obj = amulet_nbt.load(buffer=self._buffer.read(length))
+            return ConstructionSection(
+                (sx, sy, sz),
+                (shapex, shapey, shapez),
+                numpy.reshape(nbt_obj["blocks"].value, (shapex, shapey, shapez)),
+                nbt_obj["entities"].value,
+                nbt_obj["block_entities"].value,
+            )
+        else:
+            raise Exception(f"This wrapper doesn\'t support any construction version higher than {max_format_version}")
+
+    def close(self):
+        self._buffer.close()
+
+
+class ConstructionWriter:
+    def __init__(
+        self,
+        file_or_buffer: Union[str, IO],
+        source_edition: str,
+        source_version: INT_TRIPLET,
+        selection_boxes: Optional[List[Tuple[int, int, int, int, int, int]]] = None,
+        format_version: int = max_format_version,
+        section_version: int = max_section_version
+    ):
+        assert format_version <= max_format_version, f'This construction writer does not support format versions above {max_format_version}'
+        assert section_version <= max_section_version, f'This construction writer does not support section versions above {max_section_version}'
+        self._format_version = format_version
+        self._section_version = section_version
+
+        if isinstance(file_or_buffer, str):
+            self._buffer = open(file_or_buffer, "wb")
+        else:
+            assert hasattr(file_or_buffer, "write"), "Construction file buffer does not have a write mode"
+            self._buffer = file_or_buffer
+
+        self._source_edition = source_edition
+        self._source_version = source_version
+
+        self._selection_boxes = selection_boxes
+
+        self._metadata: Optional[amulet_nbt.NBTFile] = None
+        self._section_index_table: List[Tuple[int, int, int, int, int, int, int, int]] = []
+        self._palette: BlockManager = BlockManager()
+        self._init_write()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+
+    def _init_write(self):
+        """data to be written at init in write mode"""
+        self._buffer.write(magic_num)
+        if self._format_version == 0:
+            self._metadata = amulet_nbt.NBTFile(
+                amulet_nbt.TAG_Compound(
+                    {
+                        "selection_boxes": amulet_nbt.TAG_Int_Array([c for box in self._selection_boxes if len(box) == 6 and all(isinstance(c, int) for c in box) for c in box]),
+                        "section_version": amulet_nbt.TAG_Byte(self._section_version),
+                        "export_version": amulet_nbt.TAG_Compound(
+                            {
+                                "edition": amulet_nbt.TAG_String(self._source_edition),
+                                "version": amulet_nbt.TAG_List(
+                                    [amulet_nbt.TAG_Int(v) for v in self._source_version]
+                                ),
+                            }
+                        ),
+                    }
                 )
-            buffer.close()
+            )
+        else:
+            raise Exception(f"This wrapper doesn\'t support any construction version higher than {max_format_version}")
 
-        return cls.create_from(
-            section_iter(), block_palette, edition_name, edition_version, selection_boxes
+    @staticmethod
+    def _generate_block_entry(
+            _block: Block, _palette_len, _extra_blocks
+    ) -> amulet_nbt.TAG_Compound:
+        return amulet_nbt.TAG_Compound(
+            {
+                "namespace": amulet_nbt.TAG_String(_block.namespace),
+                "blockname": amulet_nbt.TAG_String(_block.base_name),
+                "properties": amulet_nbt.TAG_Compound(
+                    {
+                        prop: amulet_nbt.TAG_String(value.value)
+                        for prop, value in _block.properties.items()
+                    }
+                ),
+                "extra_blocks": amulet_nbt.TAG_List(
+                    [
+                        amulet_nbt.TAG_Int(
+                            _palette_len + _extra_blocks.index(_extra_block)
+                        )
+                        for _extra_block in _block.extra_blocks
+                    ]
+                ),
+            }
         )
+
+    def _pack_palette(self) -> amulet_nbt.TAG_List:
+        block_palette_nbt = amulet_nbt.TAG_List()
+        extra_blocks = set()
+
+        for block in self._palette.blocks():
+            if len(block.extra_blocks) > 0:
+                extra_blocks.update(block.extra_blocks)
+
+        extra_blocks = list(extra_blocks)
+
+        palette_len = len(self._palette)
+        for block_entry in self._palette.blocks():
+            block_palette_nbt.append(
+                self._generate_block_entry(block_entry, palette_len, extra_blocks)
+            )
+
+        for extra_block in extra_blocks:
+            block_palette_nbt.append(
+                self._generate_block_entry(extra_block, palette_len, extra_blocks)
+            )
+        return block_palette_nbt
+
+    def _exit_write(self):
+        """data to be written at close in write mode"""
+        if self._format_version == 0:
+            metadata_start = self._buffer.tell()
+            self._metadata["section_index_table"] = amulet_nbt.TAG_Byte_Array(
+                numpy.array(self._section_index_table, dtype=SECTION_ENTRY_TYPE).view(numpy.int8)
+            )
+            self._metadata["block_palette"] = self._pack_palette()
+            self._metadata.save_to(self._buffer)
+            INT_STRUCT.pack_into(self._buffer, 0, metadata_start)
+            self._buffer.write(magic_num)
+        else:
+            raise Exception(f"This wrapper doesn\'t support any construction version higher than {max_format_version}")
+        self._buffer.close()
+
+    @staticmethod
+    def _find_fitting_array_type(
+        array: numpy.ndarray
+    ) -> Type[Union[amulet_nbt.TAG_Int_Array, amulet_nbt.TAG_Byte_Array, amulet_nbt.TAG_Long_Array]]:
+        max_element = array.max(initial=0)
+
+        if max_element <= 127:
+            return amulet_nbt.TAG_Byte_Array
+        elif max_element <= 2_147_483_647:
+            return amulet_nbt.TAG_Int_Array
+        else:
+            return amulet_nbt.TAG_Long_Array
+
+    @overload
+    def write(
+        self,
+        min_position: INT_TRIPLET,
+        shape: INT_TRIPLET,
+        blocks: Optional[numpy.ndarray],
+        palette: List[Block],
+        entities: List[Entity],
+        block_entities: Optional[List[BlockEntity]]
+    ):
+        """section_version==0"""
+        ...
+
+    def write(self, *args, **kwargs):
+        if self._section_version == 0:
+            (sx, sy, sz), (shapex, shapey, shapez), blocks, palette, entities, block_entities = args
+            position = self._buffer.tell()
+
+            _tag = amulet_nbt.TAG_Compound(
+                {
+                    "entities": amulet_nbt.TAG_List(entities),
+                    "block_entities": amulet_nbt.TAG_List(block_entities)
+                }
+            )
+
+            if blocks is None:
+                _tag["blocks_array_type"] = amulet_nbt.TAG_Byte(-1)
+            else:
+                flattened_array = blocks.ravel()
+                lut = numpy.vectorize(self._palette.get_add_block)(palette)
+                flattened_array = lut[flattened_array]
+                array_type = self._find_fitting_array_type(flattened_array)
+                _tag["blocks_array_type"] = amulet_nbt.TAG_Byte(array_type().tag_id)
+                _tag["blocks"] = array_type(flattened_array)
+
+            amulet_nbt.NBTFile(_tag).save_to(self._buffer)
+
+            length = self._buffer.tell() - position
+            self._section_index_table.append((sx, sy, sz, shapex, shapey, shapez, position, length))
+        else:
+            raise Exception(f"This wrapper doesn\'t support any section version higher than {max_section_version}")
+
+    def close(self):
+        self._exit_write()
+        self._buffer.close()

--- a/python/construction.py
+++ b/python/construction.py
@@ -237,6 +237,7 @@ class ConstructionWriter:
             self._metadata = amulet_nbt.NBTFile(
                 amulet_nbt.TAG_Compound(
                     {
+                        "created_with": "amulet_python_wrapper",
                         "selection_boxes": amulet_nbt.TAG_Int_Array([c for box in self._selection_boxes if len(box) == 6 and all(isinstance(c, int) for c in box) for c in box]),
                         "section_version": amulet_nbt.TAG_Byte(self._section_version),
                         "export_version": amulet_nbt.TAG_Compound(
@@ -341,7 +342,7 @@ class ConstructionWriter:
         """section_version==0"""
         ...
 
-    def write(self, *args, **kwargs):
+    def write(self, *args, **_):
         if self._section_version == 0:
             (sx, sy, sz), (shapex, shapey, shapez), blocks, palette, entities, block_entities = args
             position = self._buffer.tell()

--- a/python/debug.py
+++ b/python/debug.py
@@ -1,0 +1,25 @@
+"""Log some information about a specific construction file"""
+
+import sys
+from construction import ConstructionReader
+
+
+def get_info(construction_file):
+    with ConstructionReader(construction_file) as construction:
+        print(f'Section count: {len(construction.sections)}')
+        for i, selection in enumerate(construction.selection):
+            print(f'Selection {i}, {selection}')
+        for i, block in enumerate(construction.palette):
+            print(f'Block {i}, {block}')
+        for i, (posx, posy, posz, sizex, sizey, sizez, _, _) in enumerate(construction.sections):
+            print(f'Section {i}, Pos:({posx}, {posy}, {posz}), Size:({sizex}, {sizey}, {sizez})')
+            section = construction.read(i)
+            print('\t', section.blocks)
+            print('\t', section.entities)
+            print('\t', section.block_entities)
+
+
+if __name__ == '__main__':
+    for arg in sys.argv[1:]:
+        print(arg)
+        get_info(arg)

--- a/python/debug.py
+++ b/python/debug.py
@@ -15,8 +15,10 @@ def get_info(construction_file):
             print(f'Section {i}, Pos:({posx}, {posy}, {posz}), Size:({sizex}, {sizey}, {sizez})')
             section = construction.read(i)
             print('\t', section.blocks)
-            print('\t', section.entities)
-            print('\t', section.block_entities)
+            for e in section.entities:
+                print('\t', e)
+            for e in section.block_entities:
+                print('\t', e)
 
 
 if __name__ == '__main__':

--- a/python/tests.py
+++ b/python/tests.py
@@ -234,6 +234,23 @@ class ConstructionTestCase(unittest.TestCase):
 
         self.assertEqual(sections, sections2)
 
+    def test_empty(self):
+        with ConstructionWriter("test_empty.construction", TEST_EDITION, TEST_VERSION) as construction:
+            pass
+
+        with ConstructionReader("test_empty.construction") as construction:
+            self.assertEqual(0, len(construction.sections))
+
+    def test_section_no_blocks(self):
+        with ConstructionWriter("test_section_no_blocks.construction", TEST_EDITION, TEST_VERSION) as construction:
+            construction.write((0, 0, 0), (16, 16, 16), None, self.small_block_palette, [], None)
+
+        with ConstructionReader("test_section_no_blocks.construction") as construction:
+            self.assertEqual(1, len(construction.sections))
+            section = construction.read(0)
+            self.assertEqual(section.blocks, None)
+            self.assertEqual(section.block_entities, None)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/python/tests.py
+++ b/python/tests.py
@@ -56,7 +56,7 @@ class ConstructionTestCase(unittest.TestCase):
         with ConstructionReader("test_non_cube_sections.construction") as construction:
             section = construction.read(0)
 
-        self.assertEquals(section, ConstructionSection(min_pos, shape, blocks, entities, block_entities))
+        self.assertEqual(section, ConstructionSection(min_pos, shape, blocks, entities, block_entities))
 
     @staticmethod
     def _blocks_1() -> Tuple[np.ndarray, Tuple[int, int, int]]:
@@ -84,7 +84,7 @@ class ConstructionTestCase(unittest.TestCase):
         with ConstructionReader("test_construction_creation_1.construction") as construction:
             section = construction.read(0)
 
-        self.assertEquals(section, ConstructionSection(min_pos, shape, blocks, entities, block_entities))
+        self.assertEqual(section, ConstructionSection(min_pos, shape, blocks, entities, block_entities))
 
     def test_construction_non_contiguous_1(self):
         blocks, shape = self._blocks_1()
@@ -102,7 +102,7 @@ class ConstructionTestCase(unittest.TestCase):
         with ConstructionReader("test_construction_non_contiguous_1.construction") as construction:
             sections2 = [construction.read(i) for i in range(len(construction.sections))]
 
-        self.assertEquals(sections, sections2)
+        self.assertEqual(sections, sections2)
 
     def test_construction_non_contiguous_2(self):
         blocks, shape = self._blocks_1()
@@ -120,7 +120,7 @@ class ConstructionTestCase(unittest.TestCase):
         with ConstructionReader("test_construction_non_contiguous_2.construction") as construction:
             sections2 = [construction.read(i) for i in range(len(construction.sections))]
 
-        self.assertEquals(sections, sections2)
+        self.assertEqual(sections, sections2)
 
     def test_construction_boundary_1(self):
         blocks, shape = self._blocks_1()
@@ -177,7 +177,7 @@ class ConstructionTestCase(unittest.TestCase):
         with ConstructionReader("test_construction_boundary_1.construction") as construction:
             sections2 = [construction.read(i) for i in range(len(construction.sections))]
 
-        self.assertEquals(sections, sections2)
+        self.assertEqual(sections, sections2)
 
     @unittest.skipUnless(RUN_STRESS_TEST, "Stress tests not enabled")
     def test_construction_creation_2(self):
@@ -199,7 +199,7 @@ class ConstructionTestCase(unittest.TestCase):
             sections2 = [construction.read(i) for i in range(len(construction.sections))]
         load_end = time.time()
 
-        self.assertEquals(sections, sections2)
+        self.assertEqual(sections, sections2)
 
         print(f"Saving Took: {save_end - save_start:02.4f} seconds")
         print(f"Loading Took: {load_end - load_start:02.4f} seconds")
@@ -232,7 +232,7 @@ class ConstructionTestCase(unittest.TestCase):
         with ConstructionReader("test_stacking.construction") as construction:
             sections2 = [construction.read(i) for i in range(len(construction.sections))]
 
-        self.assertEquals(sections, sections2)
+        self.assertEqual(sections, sections2)
 
 
 if __name__ == "__main__":

--- a/python/tests.py
+++ b/python/tests.py
@@ -50,17 +50,18 @@ class ConstructionTestCase(unittest.TestCase):
         entities = []
         block_entities = []
 
+        section_in = ConstructionSection(min_pos, shape, blocks, self.small_block_palette, entities, block_entities)
+
         with ConstructionWriter("test_non_cube_sections.construction", TEST_EDITION, TEST_VERSION) as construction:
-            construction.write(min_pos, shape, blocks, self.small_block_palette, entities, block_entities)
+            construction.write(section_in)
 
         with ConstructionReader("test_non_cube_sections.construction") as construction:
             section = construction.read(0)
 
-        self.assertEqual(section, ConstructionSection(min_pos, shape, blocks, entities, block_entities))
+        self.assertEqual(section, section_in)
 
     @staticmethod
-    def _blocks_1() -> Tuple[np.ndarray, Tuple[int, int, int]]:
-        shape = (16, 16, 16)
+    def _blocks_1(shape=(16, 16, 16)) -> Tuple[np.ndarray, Tuple[int, int, int]]:
         blocks = np.zeros(shape, dtype=int)
         blocks[0:8, 0:8, 0:8] = 1
         blocks[0:8, 0:8, 8:16] = 2
@@ -78,13 +79,15 @@ class ConstructionTestCase(unittest.TestCase):
         entities = []
         block_entities = []
 
+        section_in = ConstructionSection(min_pos, shape, blocks, self.small_block_palette, entities, block_entities)
+
         with ConstructionWriter("test_construction_creation_1.construction", TEST_EDITION, TEST_VERSION) as construction:
-            construction.write(min_pos, shape, blocks, self.small_block_palette, entities, block_entities)
+            construction.write(section_in)
 
         with ConstructionReader("test_construction_creation_1.construction") as construction:
             section = construction.read(0)
 
-        self.assertEqual(section, ConstructionSection(min_pos, shape, blocks, entities, block_entities))
+        self.assertEqual(section, section_in)
 
     def test_construction_non_contiguous_1(self):
         blocks, shape = self._blocks_1()
@@ -96,8 +99,9 @@ class ConstructionTestCase(unittest.TestCase):
         with ConstructionWriter("test_construction_non_contiguous_1.construction", TEST_EDITION, TEST_VERSION) as construction:
             for min_pos in product(range(0, 48, 16), range(0, 48, 16), range(0, 48, 16)):
                 if min_pos != (1, 1, 1):
-                    construction.write(min_pos, shape, blocks, self.small_block_palette, entities, block_entities)
-                    sections.append(ConstructionSection(min_pos, shape, blocks, entities, block_entities))
+                    section_in = ConstructionSection(min_pos, shape, blocks, self.small_block_palette, entities, block_entities)
+                    construction.write(section_in)
+                    sections.append(section_in)
 
         with ConstructionReader("test_construction_non_contiguous_1.construction") as construction:
             sections2 = [construction.read(i) for i in range(len(construction.sections))]
@@ -114,8 +118,9 @@ class ConstructionTestCase(unittest.TestCase):
         with ConstructionWriter("test_construction_non_contiguous_2.construction", TEST_EDITION, TEST_VERSION) as construction:
             for min_pos in product(range(0, 48, 16), range(0, 48, 16), range(0, 48, 16)):
                 if 1 not in min_pos:
-                    construction.write(min_pos, shape, blocks, self.small_block_palette, entities, block_entities)
-                    sections.append(ConstructionSection(min_pos, shape, blocks, entities, block_entities))
+                    section_in = ConstructionSection(min_pos, shape, blocks, self.small_block_palette, entities, block_entities)
+                    construction.write(section_in)
+                    sections.append(section_in)
 
         with ConstructionReader("test_construction_non_contiguous_2.construction") as construction:
             sections2 = [construction.read(i) for i in range(len(construction.sections))]
@@ -162,17 +167,21 @@ class ConstructionTestCase(unittest.TestCase):
         with ConstructionWriter("test_construction_boundary_1.construction", TEST_EDITION, TEST_VERSION) as construction:
             for min_pos in product(range(0, 48, 16), range(0, 16, 16), range(0, 48, 16)):
                 if min_pos[0] == 32 and min_pos[2] == 32:
-                    construction.write(min_pos, shape, block_layout_4, self.small_block_palette, entities, block_entities)
-                    sections.append(ConstructionSection(min_pos, shape, block_layout_4, entities, block_entities))
+                    section_in = ConstructionSection(min_pos, shape, block_layout_4, self.small_block_palette, entities, block_entities)
+                    construction.write(section_in)
+                    sections.append(section_in)
                 elif min_pos[0] == 32:
-                    construction.write(min_pos, shape, block_layout_3, self.small_block_palette, entities, block_entities)
-                    sections.append(ConstructionSection(min_pos, shape, block_layout_3, entities, block_entities))
+                    section_in = ConstructionSection(min_pos, shape, block_layout_3, self.small_block_palette, entities, block_entities)
+                    construction.write(section_in)
+                    sections.append(section_in)
                 elif min_pos[2] == 32:
-                    construction.write(min_pos, shape, block_layout_2, self.small_block_palette, entities, block_entities)
-                    sections.append(ConstructionSection(min_pos, shape, block_layout_2, entities, block_entities))
+                    section_in = ConstructionSection(min_pos, shape, block_layout_2, self.small_block_palette, entities, block_entities)
+                    construction.write(section_in)
+                    sections.append(section_in)
                 else:
-                    construction.write(min_pos, shape, blocks, self.small_block_palette, entities, block_entities)
-                    sections.append(ConstructionSection(min_pos, shape, blocks, entities, block_entities))
+                    section_in = ConstructionSection(min_pos, shape, blocks, self.small_block_palette, entities, block_entities)
+                    construction.write(section_in)
+                    sections.append(section_in)
 
         with ConstructionReader("test_construction_boundary_1.construction") as construction:
             sections2 = [construction.read(i) for i in range(len(construction.sections))]
@@ -190,8 +199,9 @@ class ConstructionTestCase(unittest.TestCase):
         save_start = time.time()
         with ConstructionWriter("test_construction_creation_2.construction", TEST_EDITION, TEST_VERSION) as construction:
             for min_pos in product(range(0, 16 * 50, 16), range(0, 16 * 50, 16), range(0, 16 * 50, 16)):
-                construction.write(min_pos, shape, blocks, self.small_block_palette, entities, block_entities)
-                sections.append(ConstructionSection(min_pos, shape, blocks, entities, block_entities))
+                section_in = ConstructionSection(min_pos, shape, blocks, self.small_block_palette, entities, block_entities)
+                construction.write(section_in)
+                sections.append(section_in)
         save_end = time.time()
 
         load_start = time.time()
@@ -205,17 +215,17 @@ class ConstructionTestCase(unittest.TestCase):
         print(f"Loading Took: {load_end - load_start:02.4f} seconds")
 
     def test_construction_creation_3(self):
-        blocks, shape = self._blocks_1()
+        blocks, shape = self._blocks_1((14, 14, 14))
         entities = []
         block_entities = []
 
         with ConstructionWriter("test_construction_creation_3.construction", TEST_EDITION, TEST_VERSION) as construction:
-            construction.write((2, 2, 2), shape, blocks, self.small_block_palette, entities, block_entities)
-            section = ConstructionSection((2, 2, 2), shape, blocks, entities, block_entities)
+            section_in = ConstructionSection((2, 2, 2), shape, blocks, self.small_block_palette, entities, block_entities)
+            construction.write(section_in)
 
         with ConstructionReader("test_construction_creation_3.construction") as construction:
             self.assertEqual(1, len(construction.sections))
-            self.assertEqual(section, construction.read(0))
+            self.assertEqual(section_in, construction.read(0))
 
     def test_stacking(self):
         blocks, shape = self._blocks_1()
@@ -226,8 +236,9 @@ class ConstructionTestCase(unittest.TestCase):
 
         with ConstructionWriter("test_stacking.construction", TEST_EDITION, TEST_VERSION) as construction:
             for min_pos in product(range(0, 16, 16), range(0, 48, 16), range(0, 16, 16)):
-                construction.write(min_pos, shape, blocks, self.small_block_palette, entities, block_entities)
-                sections.append(ConstructionSection(min_pos, shape, blocks, entities, block_entities))
+                section_in = ConstructionSection(min_pos, shape, blocks, self.small_block_palette, entities, block_entities)
+                construction.write(section_in)
+                sections.append(section_in)
 
         with ConstructionReader("test_stacking.construction") as construction:
             sections2 = [construction.read(i) for i in range(len(construction.sections))]
@@ -243,7 +254,8 @@ class ConstructionTestCase(unittest.TestCase):
 
     def test_section_no_blocks(self):
         with ConstructionWriter("test_section_no_blocks.construction", TEST_EDITION, TEST_VERSION) as construction:
-            construction.write((0, 0, 0), (16, 16, 16), None, self.small_block_palette, [], None)
+            section_in = ConstructionSection((0, 0, 0), (16, 16, 16), None, self.small_block_palette, [], None)
+            construction.write(section_in)
 
         with ConstructionReader("test_section_no_blocks.construction") as construction:
             self.assertEqual(1, len(construction.sections))

--- a/specifications/version_0/metadata.md
+++ b/specifications/version_0/metadata.md
@@ -38,8 +38,8 @@ The real format of the `section_index_table` is `IIIBBBII` where `I` is a uint32
 
 Each represents the following
 
-- `III`: The X, Y, and Z block coordinates of the section
-- `BBB`: The block shape of the section in X, Y, Z order
+- `III`: The X, Y, and Z block coordinates of the minimum point of the section
+- `BBB`: The shape of the section in blocks in X, Y, Z order
 - `I`: The starting byte of the [section data entry](section_data_table.md#section-data-entry) in the file
 - `I`: The byte length of the section data entry
 

--- a/specifications/version_0/metadata.md
+++ b/specifications/version_0/metadata.md
@@ -2,7 +2,7 @@
 The metadata for the construction is a gzip'd TAG_Compound laid out in the following format:
 
     TAG_Compound({
-        "selection_boxes": TAG_Int_Array([Nx6]),        # optional
+        "selection_boxes": TAG_Int_Array([Nx6]),
         "section_index_table": TAG_Byte_Array([Mx23]),
         "section_version": TAG_Byte(),
         "export_version": TAG_Compound({

--- a/specifications/version_0/metadata.md
+++ b/specifications/version_0/metadata.md
@@ -2,7 +2,7 @@
 The metadata for the construction is a gzip'd TAG_Compound laid out in the following format:
 
     TAG_Compound({
-        "selection_boxes": TAG_Int_Array([Nx6]),
+        "selection_boxes": TAG_Int_Array([Nx6]),        # optional
         "section_index_table": TAG_Byte_Array([Mx23]),
         "section_version": TAG_Byte(),
         "export_version": TAG_Compound({

--- a/specifications/version_0/metadata.md
+++ b/specifications/version_0/metadata.md
@@ -65,8 +65,11 @@ The `block_palette` is a list of TAG_Compound's with each containing the data fo
         "namespace": TAG_String("<block namespace>"),
         "blockname": TAG_String("<block base name>"),
         "properties": TAG_Compound({
-            "<property_name>": TAG_String("<property value>"),
-            "<property_name>": TAG_String("<property value>"),
+            "<property_name>": TAG_Byte(),
+            "<property_name>": TAG_Short(),
+            "<property_name>": TAG_Int(),
+            "<property_name>": TAG_Long(),
+            "<property_name>": TAG_String(),
             ...
         }),
         "extra_blocks": TAG_List([

--- a/specifications/version_0/section_data_table.md
+++ b/specifications/version_0/section_data_table.md
@@ -16,13 +16,25 @@ Each section data entry is a gzip'd binary TAG_Compound with the following struc
 
     TAG_Compound({
         "entities": TAG_List([
-            TAG_Compound({...}),
-            TAG_Compound({...}),
+            TAG_Compound({
+                "namespace": TAG_String(),
+                "base_name": TAG_String(),
+                "x": TAG_Double(),
+                "y": TAG_Double(),
+                "z": TAG_Double(),
+                "nbt": TAG_Compound()
+            })
             ...
         ]),
         "block_entities": TAG_List([
-            TAG_Compound({...}),
-            TAG_Compound({...}),
+            TAG_Compound({
+                "namespace": TAG_String(),
+                "base_name": TAG_String(),
+                "x": TAG_Int(),
+                "y": TAG_Int(),
+                "z": TAG_Int(),
+                "nbt": TAG_Compound()
+            })
             ...
         ]),
         "blocks_array_type": TAG_Byte(),
@@ -39,4 +51,4 @@ There is also a special case where this tag equals -1 which means that the `bloc
 The block array for each chunk is a flattened array of size specified in the [metadata section index table](metadata.md#section-index-table) with each element being an index into the [block palette](metadata.md#block-palette).
 
 ### Entities and BlockEntities
-Entities and BlockEntities are contained in a `TAG_List` with each element being a `TAG_Compound` of the entire NBT data associated with the given Entity/BlockEntity. They are serialised into the format for the version specified in the [metadata](metadata.md#export-version)
+Entities and BlockEntities are contained in a `TAG_List` with each element being a `TAG_Compound` in the format as shown above. They are converted into the format for the version specified in the [metadata](metadata.md#export-version) before they are serialised.

--- a/specifications/version_0/section_data_table.md
+++ b/specifications/version_0/section_data_table.md
@@ -29,6 +29,8 @@ In order to reduce size of the construction format, the `blocks` array can eithe
 or a `TAG_Long_Array` and the value of the `blocks_array_type` describes which of the two tag types was used by using their 
 Tag ID, which can either be  7 (for TAG_Byte_Array) or 11 (for TAG_Int_Array) or 12 (for TAG_Long_Array)
 
+There is also a special case where this tag equals -1 which means that the `blocks` and `block_entities` tag do not exist. This is useful for storing sections that contain entities but are not populated with block data.
+
 ### Blocks Array
 The block array for each chunk is a flattened array of size specified in the [metadata section index table](metadata.md#section-index-table) with each element being an index into the [block palette](metadata.md#block-palette).
 

--- a/specifications/version_0/section_data_table.md
+++ b/specifications/version_0/section_data_table.md
@@ -8,6 +8,10 @@ See [metadata's section index table](metadata.md#section-index-table) for how to
 
 A section data entry includes the data contained within a specified volume.
 
+Each volume must fit within a single sub-chunk where a sub-chunk is a 16x16x16 region of blocks with the first alligned with 0,0,0. This means that a section can be at most 16x16x16 blocks however it can be smaller by modifying the minimum coordinates and/or the section shape.
+
+There can be multiple sections per sub-chunk.
+
 Each section data entry is a gzip'd binary TAG_Compound with the following structure:
 
     TAG_Compound({

--- a/specifications/version_0/section_data_table.md
+++ b/specifications/version_0/section_data_table.md
@@ -41,14 +41,21 @@ Each section data entry is a gzip'd binary TAG_Compound with the following struc
         "blocks": <See below>
     })
 
-In order to reduce size of the construction format, the `blocks` array can either be a `TAG_Byte_Array`, a `TAG_Int_Array`,
-or a `TAG_Long_Array` and the value of the `blocks_array_type` describes which of the two tag types was used by using their 
-Tag ID, which can either be  7 (for TAG_Byte_Array) or 11 (for TAG_Int_Array) or 12 (for TAG_Long_Array)
+## Blocks
 
-There is also a special case where this tag equals -1 which means that the `blocks` and `block_entities` tag do not exist. This is useful for storing sections that contain entities but are not populated with block data.
+In order to reduce size of the construction format, the `blocks` array can be stored as any of the NBT Array types. The value of the `blocks_array_type` describes which of the tag types is used.
+
+There is also a special case where `blocks` and `block_entities` do not exist. This is useful for storing sections that contain entities but are not populated with block data.
+
+|`blocks_array_type` value|`blocks` tag type|
+|---|---|
+|-1|`blocks` and `block_entities` keys do not exist|
+|7|`TAG_Byte_Array`|
+|11|`TAG_Int_Array`|
+|12|`TAG_Long_Array`|
 
 ### Blocks Array
 The block array for each chunk is a flattened array of size specified in the [metadata section index table](metadata.md#section-index-table) with each element being an index into the [block palette](metadata.md#block-palette).
 
-### Entities and BlockEntities
+## Entities and BlockEntities
 Entities and BlockEntities are contained in a `TAG_List` with each element being a `TAG_Compound` in the format as shown above. They are converted into the format for the version specified in the [metadata](metadata.md#export-version) before they are serialised.

--- a/specifications/version_0/section_data_table.md
+++ b/specifications/version_0/section_data_table.md
@@ -16,7 +16,7 @@ Each section data entry is a gzip'd binary TAG_Compound with the following struc
             TAG_Compound({...}),
             ...
         ]),
-        "tile_entities": TAG_List([
+        "block_entities": TAG_List([
             TAG_Compound({...}),
             TAG_Compound({...}),
             ...
@@ -32,5 +32,5 @@ Tag ID, which can either be  7 (for TAG_Byte_Array) or 11 (for TAG_Int_Array) or
 ### Blocks Array
 The block array for each chunk is a flattened array of size specified in the [metadata section index table](metadata.md#section-index-table) with each element being an index into the [block palette](metadata.md#block-palette).
 
-### Entities and TileEntities
-Entities and TileEntities are contained in a `TAG_List` with each element being a `TAG_Compound` of the entire NBT data associated with the given Entity/TileEntity. They are serialised into the format for the version specified in the [metadata](metadata.md#export-version)
+### Entities and BlockEntities
+Entities and BlockEntities are contained in a `TAG_List` with each element being a `TAG_Compound` of the entire NBT data associated with the given Entity/BlockEntity. They are serialised into the format for the version specified in the [metadata](metadata.md#export-version)


### PR DESCRIPTION
A large rewrite to split reading and writing into two classes.
Support for the with operator for safely closing.
Classes no longer hold all data in memory. Instead they read/write directly to disk to reduce memory usage.
Sections can be randomly read and written.
API is a lot simpler.